### PR TITLE
Revert "Truncate oversize 'tx' messages before relaying/storing." - part of CVE-2013-4627 fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3664,16 +3664,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         CInv inv(MSG_TX, tx.GetHash());
         pfrom->AddInventoryKnown(inv);
 
-        // Truncate messages to the size of the tx in them
-        unsigned int nSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
-        unsigned int oldSize = vMsg.size();
-        if (nSize < oldSize) {
-            vMsg.resize(nSize);
-            printf("truncating oversized TX %s (%u -> %u)\n",
-                   tx.GetHash().ToString().c_str(),
-                   oldSize, nSize);
-        }
-
         bool fMissingInputs = false;
         CValidationState state;
         if (mempool.accept(state, tx, true, &fMissingInputs))


### PR DESCRIPTION
This reverts commit c40a5aaaf484855a4350fd702e8e72fd21a68155.

This commit is part of CVE-2013-4627 fix, I missed this on security fixes backports that I did some days ago, sorry for forgetfulness.

Details about is here:
https://github.com/bitcoin/bitcoin/pull/2871
